### PR TITLE
Updated for Ubuntu 14.04

### DIFF
--- a/recipes/ghc-binary.rb
+++ b/recipes/ghc-binary.rb
@@ -22,6 +22,7 @@ if node['haskell']['ghc']['packages'].length == 0
   packages = value_for_platform(
     "ubuntu" => {
       "13.04" => ["build-essential","libgmp-dev","libgmp3-dev"],
+      "14.04" => ["build-essential","libgmp-dev","libgmp3-dev"],
       "default" => ["build-essential","libgmp-dev","libgmp3-dev","libgmp3c2"],
     }
   )


### PR DESCRIPTION
Ubuntu 14.04 doesn't contain the package `libgmp3c2`, so installation fails.

This PR fixes this by making the packages installed for 14.04 the same as those for 13.04.
